### PR TITLE
Ensure all methods have bodies

### DIFF
--- a/Gaillard.SharpCover/Program.cs
+++ b/Gaillard.SharpCover/Program.cs
@@ -179,7 +179,7 @@ namespace Gaillard.SharpCover
             if (!Regex.IsMatch(type.FullName, config.TypeInclude) || Regex.IsMatch(type.FullName, config.TypeExclude))
                 return;
 
-            foreach (var method in type.Methods)
+            foreach (var method in type.Methods.Where(m => m.HasBody))
                 Instrument(method, countReference, config, writer, ref instrumentIndex);
         }
 


### PR DESCRIPTION
It appears that this crashes with an NRE at line 154 when dealing with events defined in interfaces (didn't debug too far into it). This addition fixes that issue.
