### PR TITLE
Create test for usage of an interface.

### DIFF
--- a/Gaillard.SharpCover.Tests/ProgramTests.cs
+++ b/Gaillard.SharpCover.Tests/ProgramTests.cs
@@ -32,6 +32,23 @@ namespace Gaillard.SharpCover.Tests
         }
 
         [Test]
+        public void NoBody()
+        {
+            var config =
+                @"{""assemblies"": [""bin/Debug/TestTarget.exe""], ""typeInclude"": "".*Tests.*Event.*""}";
+
+            File.WriteAllText("testConfig.json", config);
+
+            Assert.AreEqual(0, Program.Main(new []{ "instrument", "testConfig.json" }));
+
+            Process.Start(testTargetExePath).WaitForExit();
+
+            Assert.AreEqual(0, Program.Main(new []{ "check" }));
+
+            Assert.IsTrue(File.ReadLines(Program.RESULTS_FILENAME).Any());
+        }
+
+        [Test]
         public void Covered()
         {
             var config =

--- a/Gaillard.SharpCover.Tests/TestTarget.cs
+++ b/Gaillard.SharpCover.Tests/TestTarget.cs
@@ -2,6 +2,27 @@
 
 namespace Gaillard.SharpCover.Tests
 {
+    public interface IEvent
+    {
+        event EventHandler TheEvent;
+    }
+
+    public class EventUsage : IEvent
+    {
+        public event EventHandler TheEvent;
+
+        public void EventMethod(object sender, EventArgs e)
+        {
+            var i = 0;
+            i += 1;
+        }
+
+        public void RaiseEvent()
+        {
+            TheEvent(null, null);
+        }
+    }
+
     public sealed class TestTarget
     {
         public sealed class Nested
@@ -129,7 +150,7 @@ namespace Gaillard.SharpCover.Tests
                 return value.ToString();
             }
         }
-        
+
         public static void Main(string[] args)
         {
             new TestTarget().Covered();
@@ -139,6 +160,11 @@ namespace Gaillard.SharpCover.Tests
             UncoveredLeave();
             OffsetExcludes();
             LineExcludes();
+
+            var eventUsage = new Gaillard.SharpCover.Tests.EventUsage();
+            eventUsage.TheEvent += eventUsage.EventMethod;
+            eventUsage.RaiseEvent();
+            eventUsage.TheEvent -= eventUsage.EventMethod;
 
             new Constrained().ToString(5);
         }


### PR DESCRIPTION
Test breaks without the .HasBody check when grabbing methods to instrument.
