### PR TITLE
Prevent two race conditions around writer

### DIFF
--- a/Gaillard.SharpCover/Counter.cs
+++ b/Gaillard.SharpCover/Counter.cs
@@ -11,17 +11,35 @@ namespace Gaillard.SharpCover
     {
         private static object mutex = new object();
         private static BinaryWriter writer;
-        private static readonly ISet<int> indexes = new HashSet<int>();
+        private static readonly IDictionary<string,ISet<int>> indexes = new Dictionary<string,ISet<int>>();
+        private static bool registered = false;
+        private static ISet<int> set = null;
 
         public static void Count(string path, int index)
         {
             lock (mutex) {
-                if (writer == null) {
-                    writer = new BinaryWriter(File.Open(path, FileMode.Append));
+                if (!registered) {
+                    AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
+                    registered = true;
                 }
 
-                if (indexes.Add(index))
-                    writer.Write(index);
+                if (!indexes.TryGetValue(path, out set)) {
+                    indexes.Add(path, new HashSet<int>{index});
+                } else {
+                    set.Add(index);
+                }
+            }
+        }
+
+        private static void CurrentDomain_DomainUnload(object sender, EventArgs e)
+        {
+            lock (mutex) {
+                foreach (var kvp in indexes) {
+                    using (var writer = new BinaryWriter(File.Open(kvp.Key, FileMode.Append))) {
+                        foreach(var i in kvp.Value)
+                            writer.Write(i);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
AFAIK, this object isn't threadsafe. Additionally, it's possible for two
threads to assign writer to distinct objects.

In our tests we use a lot of threads. We occasionally experience what appears to be a livelock, but only with instrumented assemblies. We end up using one core at 100% and the test never finishes. I'm unsure if this change fixes the cause of the issue or just happens to prevent it due to the serialization of Count.

A more clever way to deal with the two race conditions would be to add a threadsafe queue which Count enqueued write events to rather than simply writing to the file directly.
