### PR TITLE
Don't assume xbuild will always be at /usr/bin

### DIFF
--- a/Gaillard.SharpCover.Tests/ProgramTests.cs
+++ b/Gaillard.SharpCover.Tests/ProgramTests.cs
@@ -22,7 +22,7 @@ namespace Gaillard.SharpCover.Tests
                 buildCommand = @"C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe";
                 testTargetExePath = @"bin\Debug\TestTarget.exe";
             } else {
-                buildCommand = "/usr/bin/xbuild";
+                buildCommand = "xbuild";
                 testTargetExePath = "bin/Debug/TestTarget.exe";
             }
 


### PR DESCRIPTION
Specially if you're in a Mac using mono from a Xamarin Studio installation, the binary `xbuild` will not be at `/usr/bin`.
