### PR TITLE
Don't return 1 if coverage isn't 100%

### DIFF
--- a/Gaillard.SharpCover.Tests/ProgramTests.cs
+++ b/Gaillard.SharpCover.Tests/ProgramTests.cs
@@ -77,7 +77,7 @@ namespace Gaillard.SharpCover.Tests
 
             Process.Start(testTargetExePath).WaitForExit();
 
-            Assert.AreEqual(1, Program.Main(new []{ "check" }));
+            Assert.AreEqual(0, Program.Main(new []{ "check" }));
 
             var missCount = File.ReadLines(Program.RESULTS_FILENAME).Where(l => l.StartsWith(Program.MISS_PREFIX)).Count();
             var knownCount = File.ReadLines(Program.RESULTS_FILENAME).Count();
@@ -96,7 +96,7 @@ namespace Gaillard.SharpCover.Tests
 
             Process.Start(testTargetExePath).WaitForExit();
 
-            Assert.AreEqual(1, Program.Main(new []{ "check" }));
+            Assert.AreEqual(0, Program.Main(new []{ "check" }));
 
             var missCount = File.ReadLines(Program.RESULTS_FILENAME).Where(l => l.StartsWith(Program.MISS_PREFIX)).Count();
             var knownCount = File.ReadLines(Program.RESULTS_FILENAME).Count();

--- a/Gaillard.SharpCover/Program.cs
+++ b/Gaillard.SharpCover/Program.cs
@@ -248,7 +248,7 @@ namespace Gaillard.SharpCover
 
             Console.WriteLine(string.Format("Overall coverage was {0}%.", coverage));
 
-            return missCount == 0 ? 0 : 1;
+            return 0;
         }
 
         public static int Main(string[] args)


### PR DESCRIPTION
If you return 1 when there are any missed statements, we cannot use SharpCover on codebases that aren't 100% covered in CI environments that require all steps to return 0 to continue execution.
