### PR TITLE
No need for mongodb in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: c
-services: mongodb
 install:
   - sudo apt-get install mono-devel nunit-console
 script: sh build.sh


### PR DESCRIPTION
The travis file requires MongoDB but it's not needed.